### PR TITLE
Add some missing strings for mobile (mozilla-beta 57.0)

### DIFF
--- a/ja/mobile/android/base/android_strings.dtd
+++ b/ja/mobile/android/base/android_strings.dtd
@@ -285,12 +285,6 @@
      for experimental features. -->
 <!ENTITY pref_category_experimental "実験的な機能">
 
-<!-- Custom Tabs is an Android API for allowing third-party apps to open URLs in a customized UI.
-     Instead of switching to the browser it appears as if the user stays in the third-party app.
-     For more see: https://developer.chrome.com/multidevice/android/customtabs -->
-<!ENTITY pref_custom_tabs "カスタムタブ">
-<!ENTITY pref_custom_tabs_summary3 "カスタマイズされた &brandShortName; を利用して、アプリがウェブサイトを開くことを許可します">
-
 <!-- Localization note (custom_tabs_menu_item_open_in): The variable is replaced by the name of
      default browser from user's preference, such as "Open in Firefox" -->
 <!ENTITY custom_tabs_menu_item_open_in "&formatS; で開く">
@@ -828,8 +822,8 @@ just addresses the organization to follow, e.g. "This site is run by " -->
 <!ENTITY activity_stream_topstories "&brandPocket; からのおすすめ">
 <!ENTITY activity_stream_highlights "ハイライト">
 
-<!-- LOCALIZATION NOET (activity_stream_link_more): Link-like text displayed to take user to a website with more content from Pocket. This string will be displayed in all uppercase. -->
-<!ENTITY activity_stream_link_more "詳細">
+<!-- LOCALIZATION NOTE (activity_stream_link_more1): Link-like text displayed to take user to a website with more content from Pocket. -->
+<!ENTITY activity_stream_link_more1 "詳細">
 
 <!-- LOCALIZATION NOTE (activity_stream_highlight_label_bookmarked): This label is shown in the Activity
 Stream list for highlights sourced from th user's bookmarks. -->
@@ -848,8 +842,6 @@ is simply hidden from the Activity Stream panel. -->
 <!ENTITY activity_stream_remove "消去">
 <!ENTITY activity_stream_delete_history "履歴から削除">
 
-<!ENTITY activity_stream_welcome_title "ハイライトへようこそ">
-<!ENTITY activity_stream_welcome_content1 "&brandShortName; は優れた記事や動画、ブックマーク、その他のページをあとから見返すことができるように、あなたがウェブ上で見つけたものからハイライトを作成します。">
 <!ENTITY private_tab_panel_title "プライベートブラウジングとトラッキング保護">
 <!ENTITY private_tab_panel_description "&brandShortName; は、ページ内のブラウジング行動を追跡する部分をブロックします。">
 <!ENTITY private_tab_panel_description2 "履歴は残りませんが、ダウンロードされたファイルと新しいブックマークは端末に保存されます。">

--- a/ja/mobile/android/base/sync_strings.dtd
+++ b/ja/mobile/android/base/sync_strings.dtd
@@ -51,25 +51,23 @@
 <!ENTITY fxaccount_getting_started_get_started 'はじめましょう'>
 <!ENTITY fxaccount_getting_started_old_firefox '古いバージョンの &syncBrand.shortName.label; を使っていませんか？'>
 
-<!ENTITY fxaccount_status_signed_in_as 'ログインユーザー'>
-<!ENTITY fxaccount_status_manage_account 'アカウントの管理'>
 <!ENTITY fxaccount_status_auth_server 'アカウントサーバー'>
 <!ENTITY fxaccount_status_sync_now '今すぐ同期'>
 <!ENTITY fxaccount_status_syncing2 '同期しています...'>
 <!ENTITY fxaccount_status_device_name '端末名'>
 <!ENTITY fxaccount_status_sync_server 'Sync サーバー'>
-<!ENTITY fxaccount_status_sync '&syncBrand.shortName.label;'>
-<!ENTITY fxaccount_status_sync_enabled '&syncBrand.shortName.label; は有効です'>
 <!ENTITY fxaccount_status_needs_verification2 'あなたのアカウントを確認してください。タップして確認のメールを再送信します。'>
 <!ENTITY fxaccount_status_needs_credentials '接続できません。タップしてログインします。'>
 <!ENTITY fxaccount_status_needs_upgrade 'ログインするには &brandShortName; をアップグレードする必要があります。'>
 <!ENTITY fxaccount_status_needs_master_sync_automatically_enabled '&syncBrand.shortName.label; が設定されましたが、自動では同期されません。Android の @@[@@設定@@]@@ &gt; @@[@@データ使用@@]@@ から @@[@@データの自動同期@@]@@ を有効にしてください。'>
 <!ENTITY fxaccount_status_needs_master_sync_automatically_enabled_v21 '&syncBrand.shortName.label; が設定されましたが、自動では同期されません。Android の @@[@@設定@@]@@ &gt; @@[@@アカウント@@]@@ から @@[@@データの自動同期@@]@@ を有効にしてください。'>
 <!ENTITY fxaccount_status_needs_finish_migrating 'あなたの新しい Firefox アカウントにログインするにはタップしてください。'>
+<!ENTITY fxaccount_status_choose_what '同期するものを選んでください'>
 <!ENTITY fxaccount_status_bookmarks 'ブックマーク'>
 <!ENTITY fxaccount_status_history '履歴'>
 <!ENTITY fxaccount_status_passwords2 'ログイン情報'>
 <!ENTITY fxaccount_status_tabs '開いているタブ'>
+<!ENTITY fxaccount_status_additional_settings '追加の設定'>
 <!ENTITY fxaccount_status_legal '法的事項' >
 <!-- Localization note: when tapped, the following two strings link to
      external web pages.  Compare fxaccount_policy_{linktos,linkprivacy}:
@@ -77,7 +75,6 @@
      the two uses differently. -->
 <!ENTITY fxaccount_status_linktos2 'サービス利用規約'>
 <!ENTITY fxaccount_status_linkprivacy2 '個人情報保護方針'>
-<!ENTITY fxaccount_status_more '詳細...'>
 <!ENTITY fxaccount_remove_account '接続解除...'>
 
 <!ENTITY fxaccount_remove_account_dialog_title2 'Sync の接続を解除しますか？'>
@@ -102,21 +99,6 @@
      Account. -->
 <!ENTITY fxaccount_options_title '&syncBrand.shortName.label; オプション'>
 <!ENTITY fxaccount_options_configure_title '&syncBrand.shortName.label; の設定'>
-
-<!-- Localization note: these error messages are shown after a request
-     has been made to the remote server, and an error of some type has
-     been returned. -->
-<!ENTITY fxaccount_remote_error_UPGRADE_REQUIRED 'Firefox のアップグレードが必要です'>
-
-<!-- Localization note: the format string will be fxaccount_sign_in_button_label, linkified. -->
-<!ENTITY fxaccount_remote_error_ATTEMPT_TO_CREATE_AN_ACCOUNT_THAT_ALREADY_EXISTS_2 '&formatS1; このアカウントはすでに存在します。'>
-<!ENTITY fxaccount_remote_error_ATTEMPT_TO_ACCESS_AN_ACCOUNT_THAT_DOES_NOT_EXIST 'メールかパスワードが間違っています'>
-<!ENTITY fxaccount_remote_error_INCORRECT_PASSWORD 'メールかパスワードが間違っています'>
-<!ENTITY fxaccount_remote_error_ATTEMPT_TO_OPERATE_ON_AN_UNVERIFIED_ACCOUNT 'アカウントが確認されていません'>
-<!ENTITY fxaccount_remote_error_CLIENT_HAS_SENT_TOO_MANY_REQUESTS 'サーバーが応答しません。後ほどお試しください'>
-<!ENTITY fxaccount_remote_error_SERVICE_TEMPORARILY_UNAVAILABLE_TO_DUE_HIGH_LOAD 'サーバーが応答しません。後ほどお試しください'>
-<!ENTITY fxaccount_remote_error_UNKNOWN_ERROR '問題が発生しました'>
-<!ENTITY fxaccount_remote_error_ACCOUNT_LOCKED 'アカウントがロックされています。&formatS1;'>
 
 <!ENTITY fxaccount_sync_sign_in_error_notification_title2 '&syncBrand.shortName.label; はインターネットに接続していません'>
 <!-- Localization note: the format string below will be replaced

--- a/ja/mobile/android/chrome/browser.properties
+++ b/ja/mobile/android/chrome/browser.properties
@@ -132,6 +132,14 @@ webextPerms.updateText=%S が更新されています。新しいバージョン
 
 webextPerms.updateAccept.label=更新
 
+# LOCALIZATION NOTE (webextPerms.optionalPermsHeader)
+# %S is replaced with the localized name of the extension requesting new
+# permissions.
+webextPerms.optionalPermsHeader=%S が追加の許可を必要としています。
+webextPerms.optionalPermsListIntro=追加の許可:
+webextPerms.optionalPermsAllow.label=許可
+webextPerms.optionalPermsDeny.label=拒否
+
 webextPerms.description.bookmarks=ブックマークの読み取りと変更
 webextPerms.description.browserSettings=ブラウザー設定の読み取りと変更
 webextPerms.description.browsingData=最近のブラウジング履歴、Cookie とその関連データの消去

--- a/ja/mobile/overrides/appstrings.properties
+++ b/ja/mobile/overrides/appstrings.properties
@@ -4,10 +4,10 @@
 
 # (^^; same file as browser/chrome/overrides/appstrings.properties
 
-malformedURI		=URL が正しくないため、読み込めませんでした。
+malformedURI2		=URL が正しくないため、読み込めませんでした。
 fileNotFound		=%S にはファイルが見つかりませんでした。
 fileAccessDenied=%S のファイルは読み込みできません。
-dnsNotFound		=%S という名前のサーバーが見つかりませんでした。
+dnsNotFound2		=%S のサーバーが見つかりませんでした。
 unknownProtocolFound	=%S というプロトコルはどの@@Program@@にも関連づけられてないか、このコンテキストでは許可されていないため、Firefox でこのアドレスを開く方法が分かりません。
 connectionFailure	=%S のサーバーへの接続を確立できませんでした。
 netInterrupt		=ページの読み込み中に %S への接続が切断されました。


### PR DESCRIPTION
Follow-up to https://github.com/mozilla-japan/gecko-l10n/pull/74#commitcomment-24542653

See: https://l10n.mozilla.org/dashboard/compare?run=815626

@marsf @knagato 
コメント頂いていたいくつかのMissing Translationを追加しました。レビュー頂ければ幸いです。