### PR TITLE
Bug 1402069 - Add a test string for the new localization API.

### DIFF
--- a/ja/browser/browser/preferences/main.ftl
+++ b/ja/browser/browser/preferences/main.ftl
@@ -1,0 +1,4 @@
+// Variables:
+//   $num - default value of the `dom.ipc.processCount` pref.
+default-content-process-count
+    .label = { $num } (@@Default@@)


### PR DESCRIPTION
一応lot形式のfilterキーワードをいれてますが、lot対象のファイルではないので自動変換されません。