### PR TITLE
58.0: sync calendar with en-US rev9392:62f2cf37fb0b (gecko-strings, 2017-12-12)

### DIFF
--- a/ja.status
+++ b/ja.status
@@ -867,4 +867,5 @@ editor/ui                9248:4ba5199b08ed   2017-11-02     mar             sync
 mail                     9248:4ba5199b08ed   2017-11-02     mar             sync mail
 mail                     9394:d6142a36a62d   2017-12-15     mar             sync mail
 toolkit                  9394:d6142a36a62d   2017-12-15     mar             sync toolkit
-browser                  9302:10ca26a04527   2017-12-29     hATrayflood     sync browser
+browser                  9302:10ca26a04527   2017-12-12     hATrayflood     sync browser
+calendar                 9392:62f2cf37fb0b   2017-12-12     mar             sync calendar

--- a/ja/calendar/chrome/lightning/lightning.dtd
+++ b/ja/calendar/chrome/lightning/lightning.dtd
@@ -49,7 +49,7 @@
      - tooltiptext1 is used in the calendar wizard when setting a new caldav calendar
      - tooltiptext2 is used in the calendar properties dialog for caldav calendars -->
 <!ENTITY lightning.calendarproperties.forceEmailScheduling.tooltiptext1	"今のところ、カレンダーサーバーで予定を管理している場合、このカレンダーをプロパティダイアログでセットアップした後にしか有効にできません。">
-<!ENTITY lightning.calendarproperties.forceEmailScheduling.tooltiptext2	"このオプションは、カレンダーサーバーで予定を管理している場合のみ利用可能です。有効にすると、予定がサーバーではなく標準のメールベースのスケジュールにフォールバックされます。">
+<!ENTITY lightning.calendarproperties.forceEmailScheduling.tooltiptext2	"このオプションは、カレンダーサーバーで予定を管理している場合のみ利用可能です。有効にすると、予定をサーバーではなくメールクライアント側で処理できるようにします。">
 
 <!-- iMIP Bar (meeting support) -->
 <!ENTITY lightning.imipbar.btnAccept.label			"参加">

--- a/ja/calendar/chrome/lightning/lightning.dtd
+++ b/ja/calendar/chrome/lightning/lightning.dtd
@@ -37,7 +37,19 @@
 <!ENTITY lightning.menu.eventtask.accesskey		"n">
 
 <!-- properties dialog, calendar creation wizard -->
+<!-- LOCALIZATON NOTE(lightning.calendarproperties.email.label,
+     lightning.calendarproperties.forceEmailScheduling.label)
+     These strings are used in the calendar wizard and the calendar properties dialog, but are only
+     displayed when setting/using a caldav calendar -->
 <!ENTITY lightning.calendarproperties.email.label		"メール:">
+
+<!ENTITY lightning.calendarproperties.forceEmailScheduling.label	"メールクライアント側のスケジュールを優先する">
+<!-- LOCALIZATON NOTE(lightning.calendarproperties.forceEmailScheduling.tooltiptext1,
+     lightning.calendarproperties.forceEmailScheduling.tooltiptext2)
+     - tooltiptext1 is used in the calendar wizard when setting a new caldav calendar
+     - tooltiptext2 is used in the calendar properties dialog for caldav calendars -->
+<!ENTITY lightning.calendarproperties.forceEmailScheduling.tooltiptext1	"今のところ、カレンダーサーバーで予定を管理している場合、このカレンダーをプロパティダイアログでセットアップした後にしか有効にできません。">
+<!ENTITY lightning.calendarproperties.forceEmailScheduling.tooltiptext2	"このオプションは、カレンダーサーバーで予定を管理している場合のみ利用可能です。有効にすると、予定がサーバーではなく標準のメールベースのスケジュールにフォールバックされます。">
 
 <!-- iMIP Bar (meeting support) -->
 <!ENTITY lightning.imipbar.btnAccept.label			"参加">

--- a/ja/calendar/chrome/lightning/lightning.properties
+++ b/ja/calendar/chrome/lightning/lightning.properties
@@ -213,3 +213,6 @@ integrationRestartButton=今すぐ再起動
 integrationRestartAccessKey=R
 integrationUndoButton=@@Undo@@
 integrationUndoAccessKey=U
+
+# LOCALIZATION NOTE(noIdentitySelectedNotification):
+noIdentitySelectedNotification=他の人とやり取りした招待状をこのカレンダーに保存したい場合は、メールアドレスを割り当ててください。


### PR DESCRIPTION
late-l10n for beta 58.0