### PR TITLE
"一時的なアドオンを読み込み中…"の翻訳を修正

### DIFF
--- a/ja/devtools/client/aboutdebugging.ftl
+++ b/ja/devtools/client/aboutdebugging.ftl
@@ -277,7 +277,7 @@ about-debugging-debug-target-inspect-button = 調査
 
 # Text of a button displayed in the "This Firefox" page, in the Temporary Extension
 # section. Clicking on the button will open a file picker to load a temporary extension
-about-debugging-tmp-extension-install-button = 一時的なアドオンの読み込み中...
+about-debugging-tmp-extension-install-button = 一時的なアドオンを読み込む...
 
 # Text displayed when trying to install a temporary extension in the "This Firefox" page.
 about-debugging-tmp-extension-install-error = 一時的なアドオンのインストールでエラーがありました。


### PR DESCRIPTION
`about-debugging-tmp-extension-install-button`は、`about:debugging`で一時的なアドオンを読み込むためのボタンに表示されます。
![image](https://user-images.githubusercontent.com/6533808/67262825-16de5800-f4e1-11e9-9150-e0048d45080a.png)
ここは読み込み中に表示されるメッセージではなく読み込みを開始するボタンに表示されるメッセージなので、「読み込み中…」ではなく「読み込む」のほうが適切のように見えたため、Pull Requestを作成しました。
