### PR TITLE
fix DATETIME() arguments month to long.

### DIFF
--- a/ja/browser/browser/aboutLogins.ftl
+++ b/ja/browser/browser/aboutLogins.ftl
@@ -101,9 +101,9 @@ login-item-copied-password-button-text = コピーしました！
 login-item-save-changes-button = 変更を保存
 login-item-save-new-button = 保存
 login-item-cancel-button = キャンセル
-login-item-time-changed = 最終更新日時: { DATETIME($timeChanged, day: "numeric", month: "numeric", year: "numeric") }
-login-item-time-created = 作成日時: { DATETIME($timeCreated, day: "numeric", month: "numeric", year: "numeric") }
-login-item-time-used = 最終利用日時: { DATETIME($timeUsed, day: "numeric", month: "numeric", year: "numeric") }
+login-item-time-changed = 最終更新日時: { DATETIME($timeChanged, day: "numeric", month: "long", year: "numeric") }
+login-item-time-created = 作成日時: { DATETIME($timeCreated, day: "numeric", month: "long", year: "numeric") }
+login-item-time-used = 最終利用日時: { DATETIME($timeUsed, day: "numeric", month: "long", year: "numeric") }
 
 ## OS Authentication dialog
 
@@ -221,7 +221,7 @@ confirm-discard-changes-dialog-confirm-button = 破棄
 
 about-logins-breach-alert-title = ウェブサイトからの情報漏洩
 breach-alert-text = ログイン情報の最後の更新の後に、このサイトからパスワードの漏洩、または盗難がありました。アカウントの保護のため、パスワードを変更してください。
-about-logins-breach-alert-date = この漏洩は { DATETIME($date, day: "numeric", month: "numeric", year: "numeric") } に発生しました。
+about-logins-breach-alert-date = この漏洩は { DATETIME($date, day: "numeric", month: "long", year: "numeric") } に発生しました。
 # Variables:
 #   $hostname (String) - The hostname of the website associated with the login, e.g. "example.com"
 about-logins-breach-alert-link = { $hostname } に移動

--- a/ja/browser/browser/newtab/asrouter.ftl
+++ b/ja/browser/browser/newtab/asrouter.ftl
@@ -115,7 +115,7 @@ cfr-whatsnew-tracking-protect-link-text = 報告を確認
 # localization, because it would result in the number showing twice.
 cfr-whatsnew-tracking-blocked-title = { $blockedCount }  個のトラッカーをブロックしました
 cfr-whatsnew-tracking-blocked-subtitle =
-   { DATETIME($earliestDate, month: "numeric", year: "numeric") } から
+   { DATETIME($earliestDate, month: "long", year: "numeric") } から
 cfr-whatsnew-tracking-blocked-link-text = 報告を確認
 
 cfr-whatsnew-lockwise-backup-title = パスワードをバックアップ
@@ -217,7 +217,7 @@ cfr-doorhanger-milestone-heading =
   }
 cfr-doorhanger-milestone-heading2 =
   { $blockedCount ->
-    *[other] { DATETIME($date, month: "numeric", year: "numeric") } 以降、{ -brand-short-name } は <b>{ $blockedCount } 個</b>以上のトラッカーをブロックしました！
+    *[other] { DATETIME($date, month: "long", year: "numeric") } 以降、{ -brand-short-name } は <b>{ $blockedCount } 個</b>以上のトラッカーをブロックしました！
   }
 cfr-doorhanger-milestone-ok-button = 確認
   .accesskey = S

--- a/ja/browser/browser/protections.ftl
+++ b/ja/browser/browser/protections.ftl
@@ -10,7 +10,7 @@ graph-week-summary = この 1 週間で { $count } 個のトラッカーをブ�
 #   $count (Number) - Number of tracking events blocked.
 #   $earliestDate (Number) - Unix timestamp in ms, representing a date. The
 # earliest date recorded in the database.
-graph-total-tracker-summary = { DATETIME($earliestDate, day: "numeric", month: "numeric", year: "numeric") } から <b>{ $count } 個</b>のトラッカーをブロックしました
+graph-total-tracker-summary = { DATETIME($earliestDate, day: "numeric", month: "long", year: "numeric") } から <b>{ $count } 個</b>のトラッカーをブロックしました
 
 # Text displayed instead of the graph when in Private Mode
 graph-private-window = { -brand-short-name } はプライベート@@Window@@でもトラッカーのブロックを続けますが、何をブロックしたのかは記録しません。

--- a/ja/devtools/client/application.ftl
+++ b/ja/devtools/client/application.ftl
@@ -46,7 +46,7 @@ serviceworker-worker-start3 = 開始
 
 # Text displayed for the updated time of the service worker. The <time> element will
 # display the last update time of the service worker script.
-serviceworker-worker-updated = <time>{ DATETIME($date, month: "numeric", year: "numeric", day: "numeric", hour: "numeric", minute: "numeric", second: "numeric") }</time>更新
+serviceworker-worker-updated = <time>{ DATETIME($date, month: "long", year: "numeric", day: "numeric", hour: "numeric", minute: "numeric", second: "numeric") }</time>更新
 
 # Text displayed next to the URL for the source of the service worker (e-g. "Source my/path/to/worker-js")
 serviceworker-worker-source = ソース


### PR DESCRIPTION
https://github.com/mozilla-japan/gecko-l10n/pull/243#issuecomment-776723736

> と思ったんですが、DATETIME()を使わずに日付を単発で表示するような個所では、month: long相当の2021年2月9日となってるので、これもmonth: longに統一するほうが妥当な気がしてきました。
もう1回修正します。 @marsf
>
> month: numericにしてたのはどういう表示になるか理解が浅かったために、数字ならとりあえず変な表示にはならないだろうと安全を取ったためです。