### PR TITLE
Toolkit 99.0

### DIFF
--- a/ja.filters
+++ b/ja.filters
@@ -184,13 +184,9 @@ ja-JP-mac.Export-simasita		= 書き出しました
 #	default name
 #
 ja.NewCalendarDefault			= 新しいカレンダー
-ja.NewEventDefault			= 新しい予定
 ja.NewFolderDefault			= 新しいフォルダー
-ja.NewTaskDefault			= 新しい ToDo
 ja-JP-mac.NewCalendarDefault		= 名称未設定
-ja-JP-mac.NewEventDefault		= 新規予定
 ja-JP-mac.NewFolderDefault		= 名称未設定フォルダー
-ja-JP-mac.NewTaskDefault		= 新規 ToDo
 
 
 
@@ -267,11 +263,6 @@ ja-JP-mac.AccountManager.accountTree.width	= width: 19em;
 
 #	[ toolkit module ]
 
-# toolkit/chrome/global/customizeToolbar.dtd
-ja.customizeToolbar.nstructions.description		= ドラッグ &amp; ドロップによりツールバーのアイテムを追加、削除や移動できます。
-ja-JP-mac.customizeToolbar.nstructions.description	= よく使う項目をツールバーにドラッグしてください...
-
-
 # toolkit/chrome/global/intl.css
 intl.css.common				= \
 					/* see bug-jp 4303 */\n\
@@ -292,31 +283,6 @@ intl.css.common				= \
 					}\n
 
 ja.intl.css.locale			= \
-					/* make Account Settings's height 46.6em or lower */\n\
-					@-moz-document url(chrome://messenger/content/AccountManager.xul) {\n  \
-					  .dialog-button {\n    \
-					    margin-top: 0px;\n  \
-					  }\n\
-					}\n\
-					@-moz-document url(chrome://messenger/content/am-main.xul) {\n  \
-					  separator.thin:not([orient="vertical"]) {\n    \
-					    max-height: 1px;\n  \
-					  }\n  \
-					  #identity\\.htmlSigText {\n    \
-					    height: 5em;\n  \
-					  }\n\
-					}\n\
-					@-moz-document url(chrome://messenger/content/am-server.xul) {\n  \
-					  :root {\n    \
-					    line-height: 1.2;\n  \
-					  }\n\
-					}\n\
-					@-moz-document url(chrome://messenger/content/am-copies.xul) {\n  \
-					  :root {\n    \
-					    line-height: 1.0;\n  \
-					  }\n\
-					}\n\
-					\n\
 					/* Workaround for master password dialog with Meiryo */\n\
 					#changemp {\n  \
 					  min-width: 39em;\n\
@@ -330,10 +296,3 @@ ja-JP-mac.intl.css.locale		=
 ## Firefox 10 以降
 ja.downloads.monthDate2			= %1$S%2$S日
 ja-JP-mac.downloads.monthDate2		= %1$S %2$S
-
-
-# toolkit/chrome/mozapps/downloads/settingsChange.dtd
-# mail/chrome/messanger/messangercompose/composeMsgs.properties
-# @@settingsChange.preferences@@ は Linux/Mac でのみ使用する
-ja.settingsChange.preferences		= 設定
-ja-JP-mac.settingsChange.preferences	= 環境設定

--- a/ja.status
+++ b/ja.status
@@ -1218,3 +1218,4 @@ target dir             gecko-string hg changeset rev:id     by              comm
 mail, chat, calendar    14699:a1224c86a3a3   2022-03-04     mar             sync mail, chat, calendar
 browser                 14714:bf358a19cec8   2022-03-18     hATrayflood     sync browser
 devtools                14714:bf358a19cec8   2022-03-18     hATrayflood     sync devtools
+dom, toolkit            14720:166b84b1506a   2022-03-25     mar             sync dom, toolkit

--- a/ja/dom/chrome/dom/dom.properties
+++ b/ja/dom/chrome/dom/dom.properties
@@ -40,6 +40,9 @@ FormValidationInvalidEmail		=メールアドレスを入力してください。
 FormValidationInvalidURL		=URL を入力してください。
 FormValidationInvalidDate		=正しい日付を入力してください。
 FormValidationInvalidTime		=正しい時刻を入力してください。
+FormValidationInvalidDateTime		=正しい日付と時刻を入力してください。
+FormValidationInvalidDateMonth		=正しい月を入力してください。
+FormValidationInvalidDateWeek		=正しい週を入力してください。
 FormValidationPatternMismatch		=入力された値がフィールドに指定された書式と異なります。
 # LOCALIZATION NOTE (FormValidationPatternMismatchWithTitle): %S is the (possibly truncated) title attribute value.
 FormValidationPatternMismatchWithTitle	=入力された値がフィールドに指定された書式と異なります: %S
@@ -438,3 +441,8 @@ OffscreenCanvasToBlobWarning		=OffscreenCanvas.toBlob() は推奨されません
 IDBDatabaseCreateMutableFileWarning	=IDBDatabase.createMutableFile() は推奨されません。この API が標準化された場合、https://bugzil.la/1748667 の Origin Private File System の下で実装される予定です。
 # LOCALIZATION NOTE: Do not translate "IDBMutableFile.open()"
 IDBMutableFileOpenWarning		=IDBMutableFile.open() は推奨されません。この API が標準化された場合、https://bugzil.la/1748667 の Origin Private File System の下で実装される予定です。
+
+# LOCALIZATION NOTE: Do not translate "InstallTrigger"
+InstallTriggerDeprecatedWarning		=InstallTrigger は推奨されません。これは将来のバージョンで削除されます。
+# LOCALIZATION NOTE: Do not translate "InstallTrigger.install()"
+InstallTriggerInstallDeprecatedWarning	=InstallTrigger.install() は推奨されません。これは将来のバージョンで削除されます。詳しくは https://extensionworkshop.com/documentation/publish/self-distribution/ を参照してください。

--- a/ja/mail/chrome/messenger/customizeToolbar.dtd
+++ b/ja/mail/chrome/messenger/customizeToolbar.dtd
@@ -4,7 +4,7 @@
 
 <!ENTITY dialog.title			"ツールバーのカスタマイズ">
 <!ENTITY dialog.dimensions		"width: 92ch; height: 36em;">
-<!ENTITY instructions.description	"@@customizeToolbar.nstructions.description@@">
+<!ENTITY instructions.description	"ドラッグ &amp; ドロップによりツールバーアイテムの追加、削除、移動ができます。">
 <!ENTITY show.label			"表示:">
 <!ENTITY iconsAndText.label		"アイコンとテキスト">
 <!ENTITY icons.label			"アイコンのみ">

--- a/ja/mail/chrome/messenger/messengercompose/composeMsgs.properties
+++ b/ja/mail/chrome/messenger/messengercompose/composeMsgs.properties
@@ -312,7 +312,7 @@ attachmentReminderMsg		=添付がありません。このまま送信しても�
 # See: https://developer.mozilla.org/en/Localization_and_Plurals
 # #1 number of keywords
 attachmentReminderKeywordsMsgs	= #1 個の添付キーワードが見つかりました:
-attachmentReminderOptionsMsg	=添付忘れ通知用のキーワードは@@settingsChange.preferences@@で変更できます。
+attachmentReminderOptionsMsg	=添付忘れ通知用のキーワードは設定で変更できます。
 attachmentReminderYesIForgot	=いいえ、忘れるところでした！
 attachmentReminderFalseAlarm	=はい、送信します
 

--- a/ja/toolkit/chrome/global/aboutReader.properties
+++ b/ja/toolkit/chrome/global/aboutReader.properties
@@ -64,3 +64,4 @@ aboutReader.toolbar.lineheightplus = 行間を広げます
 aboutReader.toolbar.colorschemelight = ライトの@@Color@@設定
 aboutReader.toolbar.colorschemedark = ダークの@@Color@@設定
 aboutReader.toolbar.colorschemesepia = セピアの@@Color@@設定
+aboutReader.toolbar.colorschemeauto = 自動の@@Color@@設定

--- a/ja/toolkit/chrome/global/narrate.properties
+++ b/ja/toolkit/chrome/global/narrate.properties
@@ -9,6 +9,12 @@ listen			=聴く
 back			=戻る
 start			=開始
 stop			=停止
+# %S is the keyboard shortcut for the start command
+start-label		=開始 (%S)
+# %S is the keyboard shortcut for the stop command
+stop-label		=停止 (%S)
+# Keyboard shortcut to toggle the narrate feature
+narrate-key-shortcut	=N
 forward			=進む
 speed			=速さ
 selectvoicelabel	=ボイス:

--- a/ja/toolkit/chrome/mozapps/extensions/extensions.properties
+++ b/ja/toolkit/chrome/mozapps/extensions/extensions.properties
@@ -68,7 +68,6 @@ type.locale.name	=言語パック
 type.plugin.name	=プラグイン
 type.dictionary.name	=辞書
 type.service.name	=サービス
-type.sitepermission.name	=サイト許可設定
 type.legacy.name	=旧式の拡張機能
 type.unsupported.name	=未サポート
 

--- a/ja/toolkit/toolkit/about/aboutSupport.ftl
+++ b/ja/toolkit/toolkit/about/aboutSupport.ftl
@@ -70,6 +70,12 @@ app-basics-location-service-key-google = Google Location Service キー
 app-basics-safebrowsing-key-google = Google Safebrowsing キー
 app-basics-key-mozilla = Mozilla Location Service キー
 app-basics-safe-mode = セーフモード
+app-basics-memory-size = メモリーサイズ (RAM)
+app-basics-disk-available = 空きディスク領域
+# Variables:
+#   $value (number) - Amount of data being stored
+#   $unit (string) - The unit of data being stored (e.g. MB)
+app-basics-data-size = { $value } { $unit }
 show-dir-label =
     { PLATFORM() ->
         [macos] Finder に表示

--- a/ja/toolkit/toolkit/about/aboutWebrtc.ftl
+++ b/ja/toolkit/toolkit/about/aboutWebrtc.ftl
@@ -185,30 +185,46 @@ about-webrtc-aec-logging-off-state-msg = 記録したログファイルの保存
 
 ##
 
+# This is the total number of frames encoded or decoded over an RTP stream.
+# Variables:
+#  $frames (Number) - The number of frames encoded or decoded.
+about-webrtc-frames =
+    { $frames ->
+        [one] { $frames } フレーム
+       *[other] { $frames } フレーム
+    }
+# This is the number of audio channels encoded or decoded over an RTP stream.
+# Variables:
+#  $channels (Number) - The number of channels encoded or decoded.
+about-webrtc-channels =
+    { $channels ->
+        [one] { $channels } チャンネル
+       *[other] { $channels } チャンネル
+    }
 # This is the total number of packets received on the PeerConnection.
 # Variables:
 #  $packets (Number) - The number of packets received.
 about-webrtc-received-label =
-  { $packets ->
-      [one] { $packets } パケット受信
-     *[other] { $packets } パケット受信
-  }
+    { $packets ->
+        [one] { $packets } パケット受信
+       *[other] { $packets } パケット受信
+    }
 # This is the total number of packets lost by the PeerConnection.
 # Variables:
 #  $packets (Number) - The number of packets lost.
 about-webrtc-lost-label =
-  { $packets ->
-      [one] { $packets } パケット損失
-     *[other] { $packets } パケット損失
-  }
+    { $packets ->
+        [one] { $packets } パケット損失
+       *[other] { $packets } パケット損失
+    }
 # This is the total number of packets sent by the PeerConnection.
 # Variables:
 #  $packets (Number) - The number of packets sent.
 about-webrtc-sent-label =
-  { $packets ->
-      [one] { $packets } パケット送信
-     *[other] { $packets } パケット送信
-  }
+    { $packets ->
+        [one] { $packets } パケット送信
+       *[other] { $packets } パケット送信
+    }
 # Jitter is the variance in the arrival time of packets.
 # See: https://w3c.github.io/webrtc-stats/#dom-rtcreceivedrtpstreamstats-jitter
 # Variables:


### PR DESCRIPTION
99.0+: sync dom, toolkit with en-US rev14720:166b84b1506a (2022-03-25)

remove obsoleted css hacks in /toolkit/chrome/global/intl.css and some unused filter items for Thunderbird. (issue #208)