### PR TITLE
fix typo in security.properties

### DIFF
--- a/ja/dom/chrome/security/security.properties
+++ b/ja/dom/chrome/security/security.properties
@@ -144,7 +144,7 @@ XFrameOptionsDeny	=フレーム内の “%2$S” の読み込みが “X-Frame-O
 # LOCALIZATION NOTE: %1$S is the URL of the upgraded request; %2$S is the upgraded scheme.
 HTTPSOnlyUpgradeRequest		=安全でない要求 “%1$S” が “%2$S” を使用するようにアップグレードします。
 # LOCALIZATION NOTE: %1$S is the URL of request.
-HTTPSOnlyNoUpgradeException	=安全でない要求 “%1$S” は除外されているたアップグレードされません。
+HTTPSOnlyNoUpgradeException	=安全でない要求 “%1$S” は除外されているためアップグレードされません。
 # LOCALIZATION NOTE: %1$S is the URL of the failed request; %2$S is an error-code.
 HTTPSOnlyFailedRequest		=安全でない要求 “%1$S” のアップグレードに失敗しました。(%2$S)
 # LOCALIZATION NOTE: %S is the URL of the failed request;


### PR DESCRIPTION
ja/dom/chrome/security/security.properties: 147
`HTTPSOnlyNoUpgradeException =安全でない要求 “%1$S” は除外されているたアップグレードされません。`
↓
`HTTPSOnlyNoUpgradeException =安全でない要求 “%1$S” は除外されているためアップグレードされません。`

「め」が抜けています。