### PR TITLE
不要(不適)となっているコメント行を削除

### DIFF
--- a/ja/dom/chrome/security/csp.properties
+++ b/ja/dom/chrome/security/csp.properties
@@ -1,4 +1,3 @@
-## (^m^) 未訳
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
未訳ファイルを後で見つけやすくするためのコメントが残っているが、既に翻訳完了している