### PR TITLE
add space between the month number and "月"

### DIFF
--- a/ja/calendar/chrome/calendar/calendar-event-dialog.dtd
+++ b/ja/calendar/chrome/calendar/calendar-event-dialog.dtd
@@ -312,18 +312,18 @@
 -->
 <!ENTITY event.recurrence.pattern.yearly.of.label	"">
 
-<!ENTITY event.recurrence.pattern.yearly.month.1.label		"1月">
-<!ENTITY event.recurrence.pattern.yearly.month.2.label		"2月">
-<!ENTITY event.recurrence.pattern.yearly.month.3.label		"3月">
-<!ENTITY event.recurrence.pattern.yearly.month.4.label		"4月">
-<!ENTITY event.recurrence.pattern.yearly.month.5.label		"5月">
-<!ENTITY event.recurrence.pattern.yearly.month.6.label		"6月">
-<!ENTITY event.recurrence.pattern.yearly.month.7.label		"7月">
-<!ENTITY event.recurrence.pattern.yearly.month.8.label		"8月">
-<!ENTITY event.recurrence.pattern.yearly.month.9.label		"9月">
-<!ENTITY event.recurrence.pattern.yearly.month.10.label		"10月">
-<!ENTITY event.recurrence.pattern.yearly.month.11.label		"11月">
-<!ENTITY event.recurrence.pattern.yearly.month.12.label		"12月">
+<!ENTITY event.recurrence.pattern.yearly.month.1.label		"1 月">
+<!ENTITY event.recurrence.pattern.yearly.month.2.label		"2 月">
+<!ENTITY event.recurrence.pattern.yearly.month.3.label		"3 月">
+<!ENTITY event.recurrence.pattern.yearly.month.4.label		"4 月">
+<!ENTITY event.recurrence.pattern.yearly.month.5.label		"5 月">
+<!ENTITY event.recurrence.pattern.yearly.month.6.label		"6 月">
+<!ENTITY event.recurrence.pattern.yearly.month.7.label		"7 月">
+<!ENTITY event.recurrence.pattern.yearly.month.8.label		"8 月">
+<!ENTITY event.recurrence.pattern.yearly.month.9.label		"9 月">
+<!ENTITY event.recurrence.pattern.yearly.month.10.label		"10 月">
+<!ENTITY event.recurrence.pattern.yearly.month.11.label		"11 月">
+<!ENTITY event.recurrence.pattern.yearly.month.12.label		"12 月">
 <!ENTITY event.recurrence.yearly.every.label			"毎">
 <!ENTITY event.recurrence.yearly.first.label			"第 1">
 <!ENTITY event.recurrence.yearly.second.label			"第 2">
@@ -340,18 +340,18 @@
 <!ENTITY event.recurrence.pattern.yearly.week.7.label		"土曜日">
 <!ENTITY event.recurrence.pattern.yearly.day.label		"日">
 <!ENTITY event.recurrence.of.label				"">
-<!ENTITY event.recurrence.pattern.yearly.month2.1.label		"1月">
-<!ENTITY event.recurrence.pattern.yearly.month2.2.label		"2月">
-<!ENTITY event.recurrence.pattern.yearly.month2.3.label		"3月">
-<!ENTITY event.recurrence.pattern.yearly.month2.4.label		"4月">
-<!ENTITY event.recurrence.pattern.yearly.month2.5.label		"5月">
-<!ENTITY event.recurrence.pattern.yearly.month2.6.label		"6月">
-<!ENTITY event.recurrence.pattern.yearly.month2.7.label		"7月">
-<!ENTITY event.recurrence.pattern.yearly.month2.8.label		"8月">
-<!ENTITY event.recurrence.pattern.yearly.month2.9.label		"9月">
-<!ENTITY event.recurrence.pattern.yearly.month2.10.label	"10月">
-<!ENTITY event.recurrence.pattern.yearly.month2.11.label	"11月">
-<!ENTITY event.recurrence.pattern.yearly.month2.12.label	"12月">
+<!ENTITY event.recurrence.pattern.yearly.month2.1.label		"1 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.2.label		"2 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.3.label		"3 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.4.label		"4 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.5.label		"5 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.6.label		"6 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.7.label		"7 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.8.label		"8 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.9.label		"9 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.10.label	"10 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.11.label	"11 月">
+<!ENTITY event.recurrence.pattern.yearly.month2.12.label	"12 月">
 
 <!ENTITY event.recurrence.range.label			"繰り返す期間">
 <!ENTITY event.recurrence.forever.label			"永久に繰り返す">

--- a/ja/calendar/chrome/calendar/calendar-event-dialog.properties
+++ b/ja/calendar/chrome/calendar/calendar-event-dialog.properties
@@ -93,10 +93,10 @@ repeatDetailsAnd=と
 #         and the rule of ordinalWeekdayOrder string)
 # #2 - interval
 # e.g. "the first Monday and the last Friday of every 3 months"
-## 毎月%1$S;#2か月ごとの%1$S
+## 毎月%1$S;#2 か月ごとの%1$S
 ## en-US: monthlyRuleNthOfEveryNounclass1=%1$S of every month;%1$S of every #2 months
-monthlyRuleNthOfEveryNounclass1=#2か月ごとの%1$S
-monthlyRuleNthOfEveryNounclass2=#2か月ごとの%1$S
+monthlyRuleNthOfEveryNounclass1=#2 か月ごとの%1$S
+monthlyRuleNthOfEveryNounclass2=#2 か月ごとの%1$S
 
 # LOCALIZATION NOTE (ordinalWeekdayOrder):
 # Edit recurrence window -> Recurrence pattern -> Monthly repeat rules
@@ -124,10 +124,10 @@ ordinalWeekdayOrder=%1$S %2$S
 #        noun class/gender when rule contains also specific day in the month
 # #2 - interval
 # e.g. "every Monday, Tuesday and the second Sunday of every month"
-## 毎週%1$S;#2か月ごとの毎週%1$S
+## 毎週%1$S;#2 か月ごとの毎週%1$S
 ## en-US: monthlyEveryOfEveryNounclass1=every %1$S of every month;every %1$S of every #2 months
-monthlyEveryOfEveryNounclass1=#2か月ごとの毎週%1$S
-monthlyEveryOfEveryNounclass2=#2か月ごとの毎週%1$S
+monthlyEveryOfEveryNounclass1=#2 か月ごとの毎週%1$S
+monthlyEveryOfEveryNounclass2=#2 か月ごとの毎週%1$S
 
 # LOCALIZATION NOTE (monthlyDaysOfNth_day):
 # Edit recurrence window -> Recurrence pattern -> Monthly repeat rules
@@ -143,26 +143,26 @@ monthlyDaysOfNth_day=%1$S 日
 #        of month, possibly followed by an ordinal symbol, separated with commas;
 # #2   - monthly interval
 # e.g. "days 3, 6, 9 and 12 of every 3 months"
-## 毎月 %1$S;#2か月ごとの %1$S
+## 毎月 %1$S;#2 か月ごとの %1$S
 ## en-US: monthlyDaysOfNth=%1$S of every month;%1$S of every #2 months
-monthlyDaysOfNth=#2か月ごとの %1$S
+monthlyDaysOfNth=#2 か月ごとの %1$S
 
 # LOCALIZATION NOTE (monthlyLastDayOfNth):
 # Edit recurrence window -> Recurrence pattern -> Monthly repeat rules
 # %1$S - day of month
 # #2 - month interval
 # e.g. "the last day of every 3 months"
-## 月末最終日;#1か月ごとの月末最終日
+## 月末最終日;#1 か月ごとの月末最終日
 ## en-US: monthlyLastDayOfNth=the last day of the month; the last day of every #1 months
-monthlyLastDayOfNth=#1か月ごとの月末最終日
+monthlyLastDayOfNth=#1 か月ごとの月末最終日
 
 # LOCALIZATION NOTE (monthlyEveryDayOfNth):
 # Edit recurrence window -> Recurrence pattern -> Monthly repeat rules
 # #2 - month interval
 # e.g. "every day of the month every 4 months"
-## 毎日;#2か月ごとの毎日
+## 毎日;#2 か月ごとの毎日
 ## en-US: monthlyEveryDayOfNth=every day of every month;every day of the month every #2 months
-monthlyEveryDayOfNth=#2か月ごとの毎日
+monthlyEveryDayOfNth=#2 か月ごとの毎日
 
 # LOCALIZATION NOTE (repeatOrdinal...Nounclass...):
 # Ordinal numbers nouns for every noun class (grammatical genders) of weekdays

--- a/ja/calendar/chrome/calendar/dateFormat.properties
+++ b/ja/calendar/chrome/calendar/dateFormat.properties
@@ -17,49 +17,49 @@
 # Some languages require different declensions of month names.
 # These values will be used if *.monthFormat is set to "nominative" or in places
 # where using a different declension is not yet supported.
-month.1.name=1月
-month.2.name=2月
-month.3.name=3月
-month.4.name=4月
-month.5.name=5月
-month.6.name=6月
-month.7.name=7月
-month.8.name=8月
-month.9.name=9月
-month.10.name=10月
-month.11.name=11月
-month.12.name=12月
+month.1.name=1 月
+month.2.name=2 月
+month.3.name=3 月
+month.4.name=4 月
+month.5.name=5 月
+month.6.name=6 月
+month.7.name=7 月
+month.8.name=8 月
+month.9.name=9 月
+month.10.name=10 月
+month.11.name=11 月
+month.12.name=12 月
 
 # LOCALIZATION NOTE (month.*.genitive):
 # Some languages require different declensions of month names.
 # These values will be used if *.monthFormat is set to "genitive"
 # If your language doesn't use different declensions, just set the same
 # values as for month.*.name.
-month.1.genitive=1月
-month.2.genitive=2月
-month.3.genitive=3月
-month.4.genitive=4月
-month.5.genitive=5月
-month.6.genitive=6月
-month.7.genitive=7月
-month.8.genitive=8月
-month.9.genitive=9月
-month.10.genitive=10月
-month.11.genitive=11月
-month.12.genitive=12月
+month.1.genitive=1 月
+month.2.genitive=2 月
+month.3.genitive=3 月
+month.4.genitive=4 月
+month.5.genitive=5 月
+month.6.genitive=6 月
+month.7.genitive=7 月
+month.8.genitive=8 月
+month.9.genitive=9 月
+month.10.genitive=10 月
+month.11.genitive=11 月
+month.12.genitive=12 月
 
-month.1.Mmm=(1月)
-month.2.Mmm=(2月)
-month.3.Mmm=(3月)
-month.4.Mmm=(4月)
-month.5.Mmm=(5月)
-month.6.Mmm=(6月)
-month.7.Mmm=(7月)
-month.8.Mmm=(8月)
-month.9.Mmm=(9月)
-month.10.Mmm=(10月)
-month.11.Mmm=(11月)
-month.12.Mmm=(12月)
+month.1.Mmm=(1 月)
+month.2.Mmm=(2 月)
+month.3.Mmm=(3 月)
+month.4.Mmm=(4 月)
+month.5.Mmm=(5 月)
+month.6.Mmm=(6 月)
+month.7.Mmm=(7 月)
+month.8.Mmm=(8 月)
+month.9.Mmm=(9 月)
+month.10.Mmm=(10 月)
+month.11.Mmm=(11 月)
+month.12.Mmm=(12 月)
 
 day.1.name=日曜日
 day.2.name=月曜日

--- a/ja/calendar/chrome/calendar/global.dtd
+++ b/ja/calendar/chrome/calendar/global.dtd
@@ -2,18 +2,18 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<!ENTITY month.1.name "1月" >
-<!ENTITY month.2.name "2月" >
-<!ENTITY month.3.name "3月" >
-<!ENTITY month.4.name "4月" >
-<!ENTITY month.5.name "5月" >
-<!ENTITY month.6.name "6月" >
-<!ENTITY month.7.name "7月" >
-<!ENTITY month.8.name "8月" >
-<!ENTITY month.9.name "9月" >
-<!ENTITY month.10.name "10月" >
-<!ENTITY month.11.name "11月" >
-<!ENTITY month.12.name "12月" >
+<!ENTITY month.1.name "1 月" >
+<!ENTITY month.2.name "2 月" >
+<!ENTITY month.3.name "3 月" >
+<!ENTITY month.4.name "4 月" >
+<!ENTITY month.5.name "5 月" >
+<!ENTITY month.6.name "6 月" >
+<!ENTITY month.7.name "7 月" >
+<!ENTITY month.8.name "8 月" >
+<!ENTITY month.9.name "9 月" >
+<!ENTITY month.10.name "10 月" >
+<!ENTITY month.11.name "11 月" >
+<!ENTITY month.12.name "12 月" >
 
 <!ENTITY showToday.tooltip "今日へ移動します">
 <!ENTITY onedayforward.tooltip "次の日へ移動します">


### PR DESCRIPTION
カレンダー UI で、月とその前の数字の前にスペースが入っていないのを修正
1. X月 -> X 月 (1月 -> 1 月 etc.)
2. Xか月ごとの -> X か月ごとの (#Xか月ごとの -> #X か月ごとの)