### PR TITLE
formAutofill.ftl の各国地方行政区分の編集提案

### DIFF
--- a/ja/browser/browser/preferences/formAutofill.ftl
+++ b/ja/browser/browser/preferences/formAutofill.ftl
@@ -77,11 +77,11 @@ autofill-address-suburb = 地区
 
 ## address-level-1 names
 
-autofill-address-province = 県
+autofill-address-province = 州/省/県
 autofill-address-state = 州
-autofill-address-county = 国
+autofill-address-county = 郡
 # Used in BB, JM
-autofill-address-parish = 郡
+autofill-address-parish = 教区
 # Used in JP
 autofill-address-prefecture = 都道府県
 # Used in HK
@@ -89,9 +89,9 @@ autofill-address-area = 地区
 # Used in KR
 autofill-address-do-si = 道/市
 # Used in NI, CO
-autofill-address-department = 管区
+autofill-address-department = 県
 # Used in AE
-autofill-address-emirate = 管轄区
+autofill-address-emirate = 首長国
 # Used in RU and UA
 autofill-address-oblast = 州
 


### PR DESCRIPTION
Firefox for iOS の翻訳をやっていたときに Pontoon に表示される TM に違和感があったため、TM 参照元のこちらも編集を提案させていただきます。

Province (現) 県 → (提案) 州/省/県
カナダなど...州　中国...省　スペイン...県 など定訳はないようで併記を提案します。

County (現) 国 → (提案) 郡
Count"r"y との混同？

Parish (現) 郡 → (提案) 教区
BB (バルバドス)、JM (ジャマイカ) の Wikipedia の地方行政区分を参考にしました。

Department (現) 管区 → (提案) 県
NI (ニカラグア)、CO (コロンビア) の Wikipedia の地方行政区分を参考にしました。また、iOS にはフランスにも適用される旨のコメントがありそちらも参照しました。

Emirate (現) 管轄区 → (提案) 首長国
AE (アラブ首長国連邦) 連邦を構成する各首長国が Emirate のため上記のように提案しました。

ご確認よろしくお願いします。
また、初めての PR のため作業手順などに誤りがあったら申し訳ありません。お手数ですが知らせていただけると助かります。