### PR TITLE
specificityの訳を修正

### DIFF
--- a/ja/devtools/shared/styleinspector.properties
+++ b/ja/devtools/shared/styleinspector.properties
@@ -93,7 +93,7 @@ rule.variableUnset		=%S は未設定です
 # LOCALIZATION NOTE (rule.selectorSpecificity.title): This text is used as a title attribute
 # on the selectors displayed in the inspector rules view.
 # The first argument is the computed specificity, which looks like "(0,0,1)".
-rule.selectorSpecificity.title	=限定値: %S
+rule.selectorSpecificity.title	=詳細度: %S
 
 # LOCALIZATION NOTE (rule.selectorHighlighter.tooltip): Text displayed in a
 # tooltip when the mouse is over a selector highlighter icon in the rule view.


### PR DESCRIPTION
CSSセレクターの"specificity"は、「詳細度」が定訳です。
例: https://developer.mozilla.org/ja/docs/Web/CSS/Specificity